### PR TITLE
[refactor] 기존 함수형 컴포넌트 모두 클래스형으로 전환

### DIFF
--- a/client/src/Components/ChatDetail/index.ts
+++ b/client/src/Components/ChatDetail/index.ts
@@ -19,9 +19,7 @@ export default class ChatDetail extends Component {
     return `
       <div class="chat-root">
         <header></header>
-        <div class="product-info">
-          ${InfoProduct(this.$state)}
-        </div>
+        <div class="product-info"></div>
         <div class="chat-bubbles"></div>
         <div class="chatbar"></div>
       </div>
@@ -32,6 +30,7 @@ export default class ChatDetail extends Component {
     const $header = this.$target.querySelector('header');
     const $chatBubbles = this.$target.querySelector('.chat-bubbles');
     const $chatbar = this.$target.querySelector('.chatbar');
+    const $productInfo = this.$target.querySelector('.product-info');
 
     new Header($header as HTMLElement, {
       headerType: 'menu-white',
@@ -41,5 +40,7 @@ export default class ChatDetail extends Component {
     new ChatBubble($chatBubbles as HTMLElement);
 
     new ChatBar($chatbar as HTMLElement);
+
+    new InfoProduct($productInfo as HTMLLIElement, this.$state);
   }
 }

--- a/client/src/Components/ChatList/index.ts
+++ b/client/src/Components/ChatList/index.ts
@@ -34,18 +34,19 @@ export default class Chatlist extends Component {
   template() {
     return `
       <header></header>
-      <div class="chat-lists">
-        ${this.$state.map((chat: ChatType) => ChatListItem(chat)).join('')}
-      </div>
+      <div class="chat-lists"></div>
     `;
   }
 
   mounted() {
     const $header = this.$target.querySelector('header');
+    const $chatList = this.$target.querySelector('.chat-lists');
 
     new Header($header as HTMLElement, {
       headerType: 'menu-off-white',
       title: '채팅하기',
     });
+
+    new ChatListItem($chatList as HTMLLIElement, this.$state);
   }
 }

--- a/client/src/Components/SalesProductDetail/index.ts
+++ b/client/src/Components/SalesProductDetail/index.ts
@@ -38,9 +38,7 @@ export default class SalesProductDetail extends Component {
             <p class="desc">${content}</p>
             <p class="more-info"> 채팅 0 · 관심 0 · 조회 1 </p>
           </div>
-          <div class="user-specification">
-            ${InfoSaler(users)}
-          </div>
+          <div class="user-specification"></div>
         </div>
         <div class="product-bar"></div>
       </div>
@@ -51,6 +49,9 @@ export default class SalesProductDetail extends Component {
     const { price } = this.$state;
     const $productDetail = this.$target.querySelector('.product-bar');
     const $header = this.$target.querySelector('header');
+    const $userSpecification = this.$target.querySelector(
+      '.user-specification'
+    );
 
     new Header($header as Element, {
       headerType: 'menu-invisible',
@@ -59,5 +60,7 @@ export default class SalesProductDetail extends Component {
     new ProductBar($productDetail as Element, {
       price,
     });
+
+    new InfoSaler($userSpecification as HTMLLIElement, this.$state.users);
   }
 }

--- a/client/src/Components/Shared/ChatListItem/index.ts
+++ b/client/src/Components/Shared/ChatListItem/index.ts
@@ -1,16 +1,6 @@
-// import Component from '../../../core/Component';
-
-// export default class ChatListItem extends Component {
-//   template() {
-//     const { username, timestamp, content, img } = this.$props;
-
-//     return `
-
-//     `;
-//   }
-// }
-
 import './styles';
+
+import Component from '../../../core/Component';
 
 interface ParamsType {
   username: string;
@@ -20,20 +10,27 @@ interface ParamsType {
   checked?: boolean;
 }
 
-export default function ChatListItem(chat: ParamsType) {
-  const { username, timestamp, content, img, checked } = chat;
-  return `
-    <div class="chat-list__item ${checked ? 'checked' : ''}">
-      <div class="user-section">
-        <div class="user-section__detail">
-          <h6 class="username">${username}</h6>
-          <p class="content">${content}</p>
-        </div>
-        <span class="timestamp">${timestamp}</span>
-      </div>
-      <div class="image-wrapper">
-        <img src="${img}" alt="상품 미리보기" />
-      </div>
-    </div>
-  `;
+export default class ChatListItem extends Component {
+  template() {
+    return `
+      ${this.$props
+        .map((chat: ParamsType) => {
+          return `
+            <div class="chat-list__item ${chat.checked ? 'checked' : ''}">
+              <div class="user-section">
+                <div class="user-section__detail">
+                  <h6 class="username">${chat.username}</h6>
+                  <p class="content">${chat.content}</p>
+                </div>
+                <span class="timestamp">${chat.timestamp}</span>
+              </div>
+              <div class="image-wrapper">
+                <img src="${chat.img}" alt="상품 미리보기" />
+              </div>
+            </div>
+        `;
+        })
+        .join('')}
+    `;
+  }
 }

--- a/client/src/Components/Shared/InfoProduct/index.ts
+++ b/client/src/Components/Shared/InfoProduct/index.ts
@@ -9,7 +9,7 @@ interface PropsType {
 
 export default class InfoProduct extends Component {
   template() {
-    const { title, price, image } = this.$props;
+    const { title, price, image }: PropsType = this.$props;
 
     return `
       <div class="product-intro">

--- a/client/src/Components/Shared/InfoProduct/index.ts
+++ b/client/src/Components/Shared/InfoProduct/index.ts
@@ -1,14 +1,5 @@
-// import Component from '../../../core/Component';
-
-// export default class InfoProduct extends Component {
-//   template() {
-//     return `
-//             <div>InfoProduct</div>
-//           `;
-//   }
-// }
-
 import './styles';
+import Component from '../../../core/Component';
 
 interface PropsType {
   title: string;
@@ -16,19 +7,21 @@ interface PropsType {
   image: string;
 }
 
-export default function InfoProduct(props: PropsType) {
-  const { title, price, image } = props;
+export default class InfoProduct extends Component {
+  template() {
+    const { title, price, image } = this.$props;
 
-  return `
-    <div class="product-intro">
-      <div class="image-wrapper">
-        <img src="${image}" alt="상품 미리보기" />
+    return `
+      <div class="product-intro">
+        <div class="image-wrapper">
+          <img src="${image}" alt="상품 미리보기" />
+        </div>
+        <div class="product-intro__detail">
+          <h6 class="title">${title}</h6>
+          <p calss="price">${price}</p>
+        </div>
       </div>
-      <div class="product-intro__detail">
-        <h6 class="title">${title}</h6>
-        <p calss="price">${price}</p>
-      </div>
-    </div>
-    <div class="button">판매중</div>
-  `;
+      <div class="button">판매중</div>
+    `;
+  }
 }

--- a/client/src/Components/Shared/InfoSaler/index.ts
+++ b/client/src/Components/Shared/InfoSaler/index.ts
@@ -1,18 +1,5 @@
-// import Component from '../../../core/Component';
-
-// export default class InfoSaler extends Component {
-//   template() {
-//     return `
-//       <p class="sub-title">판매자 정보</p>
-//       <div class="user-area">
-//         <p class="username">Username</p>
-//         <p class="location">역삼동</p>
-//       </div>
-//     `;
-//   }
-// }
-
 import './styles';
+import Component from '../../../core/Component';
 
 interface PropsType {
   info: string;
@@ -20,13 +7,17 @@ interface PropsType {
   location: string;
 }
 
-export default function InfoSaler(props: PropsType) {
-  const { info, name, location } = props;
-  return `
-    <p class="sub-title">${info}</p>
-    <div class="user-area">
-      <p class="username">${name}</p>
-      <p class="location">${location}</p>
-    </div>
-  `;
+export default class InfoSaler extends Component {
+  template() {
+    console.log(this.$props, this.$target);
+    const { info, name, location }: PropsType = this.$props;
+
+    return `
+      <p class="sub-title">판매자 정보</p>
+      <div class="user-area">
+        <p class="username">Username</p>
+        <p class="location">역삼동</p>
+      </div>
+    `;
+  }
 }


### PR DESCRIPTION
## 리팩토링

다음 컴포넌트를 추후 확장성을 고려해 함수형에서 클래스형으로 전환

- `ChatListItem`
- `InfoProduct`
- `InfoSaler`


## 기존구조 변경

컴포넌트 리팩토링에 따른 기존 페이지 구조 변경

- `ChatDetail`
- `ChatList`
- `SalesProductDetail`