### PR TITLE
[feature] 계정 관련 페이지 (로그인/로그아웃/회원가입) 기본 마크업 구조 작성

### DIFF
--- a/client/src/Components/Auth/Login.ts
+++ b/client/src/Components/Auth/Login.ts
@@ -1,0 +1,37 @@
+import Component from '../../core/Component';
+import TextInput from './../Shared/TextInput/index';
+import Button from './../Shared/Button/index';
+import { $router } from '../../lib/router';
+
+export default class Login extends Component {
+  template() {
+    return `
+      <div class="user-email"></div>
+      <div class="login-btn"></div>
+      <span class="link-to-register">회원가입</span>
+    `;
+  }
+
+  mounted() {
+    const $userLogin = this.$target.querySelector('.user-email');
+    const $loginBtn = this.$target.querySelector('.login-btn');
+
+    new TextInput($userLogin as HTMLElement, {
+      type: 'email',
+      placeholder: '아이디를 입력하세요.',
+      size: 'large',
+    });
+
+    new Button($loginBtn as HTMLElement, {
+      buttonType: 'large',
+      title: '로그인',
+      handleClick: () => console.log('로그인 폼 제출!'),
+    });
+  }
+
+  setEvent() {
+    this.addEvent('click', '.link-to-register', () =>
+      $router.push('/register')
+    );
+  }
+}

--- a/client/src/Components/Auth/Logout.ts
+++ b/client/src/Components/Auth/Logout.ts
@@ -1,0 +1,42 @@
+import './styles';
+import Component from '../../core/Component';
+import Header from './../Shared/Header/index';
+import Button from './../Shared/Button/index';
+import { $router } from '../../lib/router';
+
+export default class Logout extends Component {
+  setup() {
+    this.$state = {
+      username: 'username',
+    };
+  }
+  template() {
+    return `
+      <header></header>
+      <form class="authentication">
+        <div class="user-nickname">${this.$state.username}</div>
+        <div class="logout-btn"></div>
+      </form>
+    `;
+  }
+
+  mounted() {
+    const $header = this.$target.querySelector('header');
+    const $logoutBtn = this.$target.querySelector('.logout-btn');
+
+    new Header($header as HTMLElement, {
+      title: '내 계정',
+      headerType: 'menu-off-white',
+    });
+
+    new Button($logoutBtn as HTMLElement, {
+      buttonType: 'large',
+      title: '로그아웃',
+      handleClick: () => console.log('로그아웃 폼 제출!'),
+    });
+  }
+
+  setEvent() {
+    this.addEvent('click', '#left', () => $router.push('/home'));
+  }
+}

--- a/client/src/Components/Auth/Register.ts
+++ b/client/src/Components/Auth/Register.ts
@@ -1,0 +1,61 @@
+import './styles';
+import Component from '../../core/Component';
+import TextInput from './../Shared/TextInput/index';
+import Button from './../Shared/Button/index';
+import Header from './../Shared/Header/index';
+import { $router } from '../../lib/router';
+
+export default class Register extends Component {
+  template() {
+    return `
+      <header></header>
+      <form class="authentication">
+        <label for="userId">아이디
+          <div class="user-email"></div>
+        </label>
+
+        <label for="userLoc">우리 동네
+          <div class="user-location"></div>     
+        </label>
+
+        <div class="register-btn"></div>
+      </form>
+    `;
+  }
+
+  mounted() {
+    const $header = this.$target.querySelector('header');
+    const $userEmail = this.$target.querySelector('.user-email');
+    const $userLocation = this.$target.querySelector('.user-location');
+    const $registerBtn = this.$target.querySelector('.register-btn');
+
+    new Header($header as HTMLElement, {
+      title: '회원가입',
+      headerType: 'menu-off-white',
+    });
+
+    new TextInput($userEmail as HTMLElement, {
+      type: 'email',
+      placeholder: '영문, 숫자 조합 20자 이하',
+      size: 'large',
+      id: 'userId',
+    });
+
+    new TextInput($userLocation as HTMLElement, {
+      type: 'text',
+      placeholder: '시·구 제외, 동만 입력',
+      size: 'large',
+      id: 'userLoc',
+    });
+
+    new Button($registerBtn as HTMLElement, {
+      buttonType: 'large',
+      title: '회원가입',
+      handleClick: () => console.log('회원가입 폼 제출!'),
+    });
+  }
+
+  setEvent() {
+    this.addEvent('click', '#left', () => $router.push('/home'));
+  }
+}

--- a/client/src/Components/Auth/index.ts
+++ b/client/src/Components/Auth/index.ts
@@ -1,0 +1,27 @@
+import './styles';
+import Component from '../../core/Component';
+import Header from '../Shared/Header';
+import Login from './Login';
+
+export default class Auth extends Component {
+  setup() {}
+
+  template() {
+    return `
+      <header></header>
+      <form class="authentication"></form>
+    `;
+  }
+
+  mounted() {
+    const $header = this.$target.querySelector('header');
+    const $authentication = this.$target.querySelector('.authentication');
+
+    new Header($header as HTMLElement, {
+      title: '로그인',
+      headerType: 'menu-off-white',
+    });
+
+    new Login($authentication as HTMLElement);
+  }
+}

--- a/client/src/Components/Auth/styles.scss
+++ b/client/src/Components/Auth/styles.scss
@@ -1,0 +1,45 @@
+@import '../../scss/theme';
+
+.authentication {
+  margin-top: 1rem;
+  display: inline-flex;
+  flex-direction: column;
+  padding: 1.6rem;
+  gap: 2rem;
+
+  label {
+    @include text-small;
+    color: $title-active;
+
+    input {
+      margin-top: 1rem;
+    }
+  }
+
+  .user-email {
+    @include text-medium;
+    color: $grey1;
+  }
+
+  .login-btn {
+    @include link-medium;
+  }
+
+  .link-to-register {
+    padding: 1rem;
+    text-align: center;
+    cursor: pointer;
+    @include link-small;
+
+    &:hover {
+      opacity: 0.75;
+    }
+  }
+
+  .user-nickname {
+    @include link-small;
+    color: $title-active;
+    text-align: center;
+    padding: 1rem;
+  }
+}

--- a/client/src/Components/Home/index.ts
+++ b/client/src/Components/Home/index.ts
@@ -8,6 +8,7 @@ import CategoryListItem, {
 import Header from '../shared/Header';
 import './styles.scss';
 import Menu from '../Menu';
+import Auth from './../Auth/index';
 
 const list: CategoryListItemProps[] = [];
 [0, 0, 0, 0, 0, 0, 0, 0, 0].forEach(() => {
@@ -37,6 +38,7 @@ export default class Home extends Component {
     <div id="item-list"></div>
     <div id="menu-modal" class="modal-close"></div>
     <div id="category-modal" class="modal-close"></div>
+    <div id="user-modal" class="modal-close"></div>
     `;
   }
   mounted() {
@@ -64,6 +66,11 @@ export default class Home extends Component {
       document.createElement('div');
     new Menu($menuModal as Element);
 
+    const $userModal =
+      this.$target.querySelector('#user-modal') ||
+      document.createElement('div');
+    new Auth($userModal as Element);
+
     // buttons
     const $categoryBtn = this.$target.querySelector('#category');
     $categoryBtn?.addEventListener('click', () => {
@@ -73,6 +80,11 @@ export default class Home extends Component {
     const $menuBtn = this.$target.querySelector('#menu');
     $menuBtn?.addEventListener('click', () => {
       $menuModal.className = 'modal-open';
+    });
+
+    const $userBtn = this.$target.querySelector('#user');
+    $userBtn?.addEventListener('click', () => {
+      $userModal.className = 'modal-open';
     });
 
     const $backBtns = this.$target.querySelectorAll('#left');

--- a/client/src/Components/Shared/TextInput/index.ts
+++ b/client/src/Components/Shared/TextInput/index.ts
@@ -1,0 +1,19 @@
+import './styles';
+import Component from '../../../core/Component';
+
+interface PropsType {
+  placeholder: string;
+  type: string;
+  size: string;
+  id?: string;
+}
+
+export default class TextInput extends Component {
+  template() {
+    const { placeholder, type, size, id }: PropsType = this.$props;
+
+    return `
+      <input id="${id}" class="text-input size-${size}" placeholder="${placeholder}" type="${type}" />
+    `;
+  }
+}

--- a/client/src/Components/Shared/TextInput/styles.scss
+++ b/client/src/Components/Shared/TextInput/styles.scss
@@ -1,0 +1,24 @@
+@import '../../../scss/theme';
+
+input.text-input {
+  border: 1px solid $grey3;
+  outline: none;
+  box-sizing: border-box;
+  border-radius: 0.8rem;
+
+  &.size-medium {
+    padding: 0.8rem;
+    width: 25.6rem;
+    height: 3.6rem;
+  }
+
+  &.size-large {
+    padding: 1.6rem 1rem;
+    width: 29rem;
+    height: 4rem;
+  }
+
+  &:focus {
+    border: 1px solid $primary;
+  }
+}

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -4,7 +4,8 @@ import Home from './Components/Home';
 import SalesProductDetail from './Components/SalesProductDetail';
 import Chatlist from './Components/ChatList/index';
 import ChatDetail from './Components/ChatDetail';
-
+import Register from './Components/Auth/Register';
+import Logout from './Components/Auth/Logout';
 
 const $app = document.querySelector('#app');
 const routes = [
@@ -13,6 +14,8 @@ const routes = [
   { path: '/post', component: SalesProductDetail },
   { path: '/chat', component: Chatlist },
   { path: '/chat/:id', component: ChatDetail },
+  { path: '/register', component: Register },
+  { path: '/logout', component: Logout },
   // { path: '/login', component: LoginPage },
   // { path: '/stores', component: StorePage },
 ];


### PR DESCRIPTION
- 로그인 / 로그아웃 / 회원가입 페이지 기본 마크업 구조 작성
- 해당 페이지 및 다른 페이지에서 필요한 `TextInput` 컴포넌트 클래스 구현
  - props
    - `type`: input의 type : eg. text, eamil, password, ....
    - `placeholder`: input의 placeholder 속성
    - `size` : medium 또는 large
    - `id` : 선택값, 필요 시 지정할 id 값

- 로그인 페이지 : `Home` 과 연결되어 슬라이딩 애니메이션으로 페이지 전환
- 회원가입 및 로그아웃 : 라우팅을 타고 이동