### PR TITLE
[fefactor] dropdown 클래스 컴포넌트 렌더링 로직 변경

### DIFF
--- a/client/src/Components/Home/index.ts
+++ b/client/src/Components/Home/index.ts
@@ -9,6 +9,7 @@ import './styles.scss';
 import Menu from '../Menu';
 import Button from '../Shared/Button';
 import Auth from './../Auth/index';
+import Dropdown from './../Shared/Dropdown/index';
 
 const list: CategoryListItemProps[] = [];
 [0, 0, 0, 0, 0, 0, 0, 0, 0].forEach(() => {
@@ -91,7 +92,21 @@ export default class Home extends Component {
     });
 
     const $locationBtn = this.$target.querySelector('.location');
-    $locationBtn?.addEventListener('click', () => $router.push('/location'));
+    new Dropdown($locationBtn as HTMLElement, {
+      lists: [
+        {
+          text: '역삼동',
+          isWarning: false,
+          onclick: () => console.log('역삼동 설정 완료!!'),
+        },
+        {
+          text: '내 동네 설정하기',
+          isWarning: false,
+          onclick: () => $router.push('/location'),
+        },
+      ],
+      offset: 'center',
+    });
 
     const $backBtns = this.$target.querySelectorAll('#left');
     $backBtns.forEach((btn) => {

--- a/client/src/Components/SalesProductDetail/index.ts
+++ b/client/src/Components/SalesProductDetail/index.ts
@@ -74,7 +74,24 @@ export default class SalesProductDetail extends Component {
       text: '판매중',
     });
 
+    const $moreBtn = $header?.querySelector('#right');
+    new Dropdown($moreBtn as HTMLElement, {
+      lists: [
+        {
+          text: '수정하기',
+          isWarning: false,
+          onclick: () => console.log('수정이벤트 발생'),
+        },
+        {
+          text: '삭제하기',
+          isWarning: true,
+          onclick: () => console.log('삭제이벤트 발생'),
+        },
+      ],
+      offset: 'right',
+    });
+
     const $backBtn = $header?.querySelector('#left');
-    $backBtn?.addEventListener('click', () => $router.push('/home'))
+    $backBtn?.addEventListener('click', () => $router.push('/home'));
   }
 }

--- a/client/src/Components/Shared/Dropdown/index.ts
+++ b/client/src/Components/Shared/Dropdown/index.ts
@@ -1,38 +1,63 @@
 import './styles';
 import Component from '../../../core/Component';
 
-export default class Dropdown extends Component {
-  template() {
-    const { lists } = this.$props;
+interface DropdownListType {
+  isWarning?: boolean;
+  text: string;
+  onclick: Function;
+}
 
-    return `
-      ${lists
-        .map(
-          (list) =>
-            `<li class="dropdown-item ${list.isWarning ? 'warning' : ''}">${
-              list.text
-            }</li>`
-        )
-        .join('')}
-    `;
+export default class Dropdown extends Component {
+  setup() {
+    const { offset } = this.$props;
+    const $dropdown = document.createElement('ul');
+    $dropdown.classList.add('dropdown', offset);
+    this.$target.append($dropdown);
+    this.$target.style.position = 'relative';
   }
 
   mounted() {
-    const { offset } = this.$props;
-    const dropdownOpener = this.$target.parentElement;
+    const { lists, offset } = this.$props;
+    const $dropdown = this.$target.querySelector('.dropdown') as HTMLElement;
 
-    const toggleDropdown = () => {
-      const currentStatus = this.$target.style.display;
+    const dropdownOpener = $dropdown?.parentElement;
 
-      if (!currentStatus || currentStatus === 'none') {
-        this.$target.style.display = 'block';
+    // const dropdownItems = lists
+    //   .map((list: DropdownListType) => {
+    //     return `
+    //     <li class="dropdown-item ${list.isWarning ? 'warning' : ''}">
+    //       ${list.text}
+    //     </li>
+    //   `;
+    //   })
+    //   .join('');
+    // $dropdown!.innerHTML = dropdownItems;
+
+    // template literal로 이벤트콜백 `<li onclick=${onclick}>...</li>` 를 넣는 방법이 있을까요오오?
+
+    lists.forEach((list: DropdownListType) => {
+      const { isWarning, text, onclick } = list;
+      const $li = document.createElement('li');
+      $li.classList.add('dropdown-item');
+      if (isWarning) $li.classList.add('warning');
+      $li.innerText = text;
+      $li.addEventListener('click', () => onclick());
+      $dropdown.append($li);
+    });
+
+    const toggleDropdown = (e: MouseEvent) => {
+      e.stopPropagation();
+      const isOpen = $dropdown.className.includes('open-dropdown');
+
+      if (isOpen) {
+        $dropdown.classList.remove('open-dropdown');
       } else {
-        this.$target.style.display = 'none';
+        $dropdown.classList.add('open-dropdown');
       }
     };
 
     this.$target?.classList.add(offset);
-    dropdownOpener.addEventListener('click', toggleDropdown);
+    dropdownOpener?.addEventListener('click', (e) => toggleDropdown(e));
   }
 
   setEvent() {

--- a/client/src/Components/Shared/Dropdown/styles.scss
+++ b/client/src/Components/Shared/Dropdown/styles.scss
@@ -7,11 +7,15 @@
   border: 1px solid $grey3;
   background-color: $off-white;
   border-radius: 1rem;
+  box-shadow: 0px 0px 4px rgba(204, 204, 204, 0.5),
+    0px 2px 4px rgba(0, 0, 0, 0.25);
+  backdrop-filter: blur(4px);
 
   .dropdown-item {
     width: 16.5rem;
     padding: 1.6rem;
-    @include text-small;
+    @include link-small;
+    color: $title-active;
     box-sizing: border-box;
     cursor: pointer;
 
@@ -39,5 +43,9 @@
   &.center {
     left: 50%;
     transform: translateX(-50%);
+  }
+
+  &.open-dropdown {
+    display: block;
   }
 }

--- a/client/src/Components/Shared/Header/styles.scss
+++ b/client/src/Components/Shared/Header/styles.scss
@@ -41,5 +41,15 @@
   background-color: $off-white;
 }
 .menu-invisible {
-  background-color: none;
+  background-color: transparent;
+  justify-content: space-between;
+  box-sizing: border-box;
+  padding: 0 1.6rem;
+
+  #left,
+  #right {
+    position: relative;
+    left: 0;
+    right: 0;
+  }
 }

--- a/client/src/Components/Shared/Status/index.ts
+++ b/client/src/Components/Shared/Status/index.ts
@@ -10,13 +10,12 @@ export default class Status extends Component {
     return `
         <span>${text}</span>
         <div class="icon-button"></div>
-        <ul class="dropdown"></ul>
     `;
   }
 
   mounted() {
     const $status = this.$target.querySelector('.icon-button');
-    const $dropdown = this.$target.querySelector('.dropdown');
+    const $dropdown = this.$target;
 
     new IconButton($status as HTMLElement, {
       name: 'down-xs',
@@ -24,10 +23,17 @@ export default class Status extends Component {
 
     new Dropdown($dropdown as HTMLElement, {
       lists: [
-        { text: '예약중으로 변경', isWarning: false },
-        { text: '판매완료로 변경', isWarning: false },
+        {
+          text: '예약중으로 변경',
+          isWarning: false,
+          onclick: () => console.log('예약중'),
+        },
+        {
+          text: '판매완료로 변경',
+          isWarning: false,
+          onclick: () => console.log('판매완료'),
+        },
       ],
-      onclick: () => console.log(1),
       offset: 'left',
     });
   }

--- a/client/src/core/Component.ts
+++ b/client/src/core/Component.ts
@@ -15,7 +15,10 @@ export default class Component {
     return '';
   }
   render() {
-    this.$target.innerHTML = this.template();
+    const template = this.template();
+    if (template) {
+      this.$target.innerHTML = template;
+    }
     this.mounted();
   }
   setEvent() {}

--- a/client/src/lib/router.ts
+++ b/client/src/lib/router.ts
@@ -113,6 +113,19 @@ export let $router: {
  * @param {{$app: HTMLElement, routes: Route[], fallback?: string}} options
  */
 export function initRouter(options: RouterType) {
+  // dropdown 영역 밖 클릭 시 드랍다운 제거 이벤트는 최상단 $app에서 관리
+  const { $app } = options;
+  $app.addEventListener('click', (e: MouseEvent) => {
+    const $dropdowns = $app.querySelectorAll('.dropdown');
+    $dropdowns.forEach(($dropdown: HTMLElement) => {
+      const isOpen = $dropdown.className.includes('open-dropdown');
+
+      if (isOpen) {
+        $dropdown.classList.remove('open-dropdown');
+      }
+    });
+  });
+
   const router = new Router(options);
 
   $router = {


### PR DESCRIPTION
- 기존 드랍다운 클래스가 하나의 컴포넌트에 종속되어 있던 점을 수정했습니다.
- 이 과정에서 코어 클래스 중 두 가지가 변경되었습니다.

1. `Router` 클래스
  - `initRouter` 부분에 최상단 루트단에 클릭 이벤트 추가 (이벤트위임 패턴)

2. `Component` 클래스
  - `render()` 메서드 `template()` 변화가 없을 경우 `mouted()` 메서드만 실행
