### PR TITLE
[bugfix] slider 이미지가 1장일 때는 carousel 기능 제거

### DIFF
--- a/client/src/Components/Shared/ImgBox/styles.scss
+++ b/client/src/Components/Shared/ImgBox/styles.scss
@@ -29,26 +29,10 @@
   height: 10.6rem;
 }
 .imgbox-gradient {
-  position: relative;
   width: 100%;
   height: 35rem;
   display: flex;
-  background-size: cover;
+  background-size: 100% 100%;
   align-items: center;
   justify-content: center;
-  &::after {
-    width: 100%;
-    height: 35rem;
-    content: '';
-    position: absolute;
-    top: 0;
-    left: 0;
-    background: linear-gradient(
-      180deg,
-      rgba(0, 0, 0, 0.24) 0%,
-      rgba(0, 0, 0, 0) 16.52%,
-      rgba(0, 0, 0, 0) 87.36%,
-      rgba(0, 0, 0, 0.24) 100%
-    );
-  }
 }

--- a/client/src/Components/Shared/ImgNavigation/index.ts
+++ b/client/src/Components/Shared/ImgNavigation/index.ts
@@ -33,8 +33,6 @@ export default class ImgNavigation extends Component {
     ) as HTMLElement;
     const $imageNav = this.$target.querySelector('.image-nav');
 
-    $navigation.style.width = 100 * (images?.length + 2) + '%';
-
     images?.forEach((image: string, index: number) => {
       const $div = document.createElement('div');
       $div.classList.add('navigation-item', `image-target-${index}`);
@@ -47,7 +45,10 @@ export default class ImgNavigation extends Component {
 
     new NavItem($imageNav as HTMLElement, images);
 
-    this.initSlider({ $navigation });
+    if (images?.length > 1) {
+      $navigation.style.width = 100 * (images?.length + 2) + '%';
+      this.initSlider({ $navigation });
+    }
   }
 
   private initSlider({ $navigation }: SliderTypes) {

--- a/client/src/Components/Shared/ImgNavigation/styles.scss
+++ b/client/src/Components/Shared/ImgNavigation/styles.scss
@@ -16,6 +16,22 @@
       width: 100%;
       transition: all 1s;
     }
+
+    &::after {
+      width: 100%;
+      height: 35rem;
+      content: '';
+      position: absolute;
+      top: 0;
+      left: 0;
+      background: linear-gradient(
+        180deg,
+        rgba(0, 0, 0, 0.24) 0%,
+        rgba(0, 0, 0, 0) 16.52%,
+        rgba(0, 0, 0, 0) 87.36%,
+        rgba(0, 0, 0, 0.24) 100%
+      );
+    }
   }
 
   .image-nav {

--- a/client/src/lib/router.ts
+++ b/client/src/lib/router.ts
@@ -138,7 +138,7 @@ function handleMutationObserver($app: HTMLElement) {
   const observer = new MutationObserver((mutationRecord) => {
     const $slider = $app.querySelector('.image-navigation') as HTMLElement;
 
-    if ($slider) {
+    if ($slider && $slider.childElementCount > 1) {
       const record = mutationRecord.filter((record) => {
         const isActive = (<HTMLElement>record.target).className.includes(
           'active'


### PR DESCRIPTION
- 이미지가 1장일때도 무한 슬라이더 기능이 적용되던 버그를 수정했습니다.
- 추가적으로 이미지 크기가 슬라이드 화면에 맞게 수정했습니다.
- image-gradient 중복 문제를 해결했습니다.